### PR TITLE
DEVOPS-843: Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'
       - name: install


### PR DESCRIPTION
This PR updates GitHub Actions to use commit SHAs instead of tags or branches.

Updated files:
- .github/workflows/ci.yml